### PR TITLE
Widen Python support to 3.10–3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* Python compatibility widened to `>=3.10, <3.14` (was `>=3.10, <=3.11`). Added 3.12 / 3.13 to
+  classifiers. The package has been used in production on 3.13 with the previous constraint
+  bypassed via `pip install --ignore-requires-python`; this change makes that unnecessary.
+
 ## [0.2.0] - 2022-11-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,13 @@ classifiers = [
     'Natural Language :: English',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 packages = [{ include = "drebedengi", from = "src" }]
 
 [tool.poetry.dependencies]
-python = ">=3.10, <=3.11"
+python = ">=3.10, <3.14"
 click = "^8.1.3"
 zeep = "^4.2.0"
 attrs = "^22.1.0"


### PR DESCRIPTION
First half of the split requested in #13 (cc @mishamsk). This one is **only** the Python version bump — no code changes.

### What

* `pyproject.toml`: `python = ">=3.10, <3.14"` (was `>=3.10, <=3.11`)
* Added Python 3.12 / 3.13 to classifiers
* CHANGELOG entry under `[Unreleased] / Changed`

### Why

The previous constraint is stale. The library actually runs fine on 3.12 and 3.13 — we've been using it with `pip install --ignore-requires-python` against a real Drebedengi account on 3.13 (verified live: `get_current_revision`, `get_accounts`, `get_expense_categories`, `get_income_sources`, `get_transactions` all return data). This change just removes the artificial wall.

### Verification

* `pip install .` on Python 3.13 — no warning, no `--ignore-requires-python` needed.
* `pytest tests/` — 15 passed (no test changes in this PR).

The other half of #13 (Currency / xmlmap fixes) is in a separate PR.