### PR TITLE
Fix get_currencies on user-defined currencies without ISO code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* `api.get_currencies()` no longer crashes for user-defined currencies that don't carry an
+  ISO-4217 code. `Currency.currency_code` is now `str | None` (default `None`).
+* `xmlmap_to_model()` honours `attrs` field defaults in strict mode — missing/empty XML values
+  for fields with an explicit default no longer raise `ValueError`.
+
 ## [0.2.0] - 2022-11-12
 
 ### Added

--- a/src/drebedengi/model.py
+++ b/src/drebedengi/model.py
@@ -290,7 +290,8 @@ class Currency:
     Attributes:
         id (int): id is a unique drebedengi internal identifier for the currency.
         user_name (str): A custom currency name assigned by the user.
-        currency_code (str): International 3-leet currency code.
+        currency_code (str | None): International 3-letter currency code. May be absent for
+            user-defined currencies that don't carry an ISO-4217 code.
         exchange_rate (float): Current exchange rate from the default currency to the currency.
         budget_family_id (int): User family ID (for multiuser mode)
         is_default (bool): True if the currency is set as default.
@@ -300,7 +301,12 @@ class Currency:
 
     id: int = field(converter=int)
     user_name: str = field(converter=str, metadata={"xml": {"name": "name"}})
-    currency_code: str = field(converter=str, metadata={"xml": {"name": "code"}})
+    currency_code: str | None = field(
+        default=None,
+        kw_only=True,
+        converter=optional(str),
+        metadata={"xml": {"name": "code"}},
+    )
     exchange_rate: float = field(converter=float, metadata={"xml": {"name": "course"}})
     budget_family_id: int = field(converter=int, metadata={"xml": {"name": "family_id"}})
     is_default: bool = field(converter=to_bool)

--- a/src/drebedengi/utils.py
+++ b/src/drebedengi/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from attrs import fields_dict, has
+from attrs import NOTHING, fields_dict, has
 from lxml import etree
 from zeep import xsd
 from zeep.helpers import guess_xsd_type
@@ -45,6 +45,9 @@ def xmlmap_to_model(xmlmap: etree.Element, model_type: Type[T], *, strict: bool 
         value = _get_xmlmap_value_by_key(xmlmap, key=key)
         if value:
             vals[name] = value[0]
+        elif field.default is not NOTHING:
+            # Field has an explicit default — leave it to attrs (do not error out, even in strict mode).
+            continue
         elif strict and not (field.type and isinstance(None, field.type)):
             raise ValueError(
                 f"Key <{name}> was not found in the element {etree.tostring(xmlmap, pretty_print=True)}"

--- a/tests/test_xmlmap.py
+++ b/tests/test_xmlmap.py
@@ -1,0 +1,50 @@
+"""Unit tests for xmlmap_to_model and models that hit XML edge cases."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from drebedengi.model import Currency
+from drebedengi.utils import xmlmap_to_model
+
+
+NS = 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"'
+
+
+def _make_currency_xml(*, with_code: str | None) -> etree.Element:
+    code_tag = (
+        f'<value xsi:type="xsd:string">{with_code}</value>'
+        if with_code is not None
+        else '<value xsi:type="xsd:string"/>'
+    )
+    src = f"""<item {NS}>
+        <item><key>id</key><value xsi:type="xsd:string">42</value></item>
+        <item><key>name</key><value xsi:type="xsd:string">руб</value></item>
+        <item><key>course</key><value xsi:type="xsd:string">1</value></item>
+        <item><key>code</key>{code_tag}</item>
+        <item><key>family_id</key><value xsi:type="xsd:string">283054</value></item>
+        <item><key>is_default</key><value xsi:type="xsd:string">t</value></item>
+        <item><key>is_autoupdate</key><value xsi:type="xsd:string">f</value></item>
+        <item><key>is_hidden</key><value xsi:type="xsd:string">f</value></item>
+    </item>"""
+    return etree.fromstring(src)
+
+
+def test_currency_with_iso_code():
+    xml = _make_currency_xml(with_code="USD")
+    cur = xmlmap_to_model(xml, Currency, strict=True)
+    assert cur.id == 42
+    assert cur.user_name == "руб"
+    assert cur.currency_code == "USD"
+    assert cur.is_default is True
+
+
+def test_currency_without_iso_code_does_not_crash():
+    """Regression: user-defined currencies (e.g. RUB nicknamed 'руб') may have an empty <code>.
+    The model must tolerate this and set currency_code=None instead of raising ValueError.
+    """
+    xml = _make_currency_xml(with_code=None)
+    cur = xmlmap_to_model(xml, Currency, strict=True)
+    assert cur.id == 42
+    assert cur.user_name == "руб"
+    assert cur.currency_code is None


### PR DESCRIPTION
Second half of the split requested in #13 (cc @mishamsk). This one is **only** the `Currency` / `xmlmap_to_model` fix — no Python version changes.

### Symptom

On accounts that have a custom-named currency (e.g. the default rouble nicknamed in Russian), `getCurrencyList` returns an empty `<code>` element, and the strict mapper dies:

```
ValueError: Key <currency_code> was not found in the element
    <key xsi:type="xsd:string">code</key>
    <value xsi:type="xsd:string"/>
```

### Fix (two parts)

1. `Currency.currency_code` is now `str | None` (default `None`, `kw_only=True` to keep the positional API of subsequent fields). Docstring updated.
2. `xmlmap_to_model()` honours `attrs` field defaults in strict mode: if the XML value is missing and `field.default is not NOTHING`, the mapper skips it rather than raising. Model authors can now mark optional XML elements via `default=...` without disabling strict mode globally.

### Tests

* New `tests/test_xmlmap.py` with two regression cases (Currency with and without ISO code).
* Existing tests untouched.
* `pytest tests/` → 17 passed (15 existing + 2 new).
* Live smoke against a real account on Python 3.13: `get_currencies()` returns 10 currencies — one with `currency_code=None` (the user-named rouble) and several with normal ISO codes.

### Backwards compatibility

* Positional `Currency(...)` callers up to `currency_code` keep working — the field is `kw_only=True` and didn't move.
* `xmlmap_to_model()` behaviour only changes for fields that explicitly declare a `default`. No existing model field does, so nothing in the current code base is affected.