### PR TITLE
Add api.delete_object (second write method)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* `api.delete_object(object_id=..., object_type=...)` — wraps the `deleteObject` SOAP method.
+  `object_type` is a `Literal[...]` of the eight WSDL-allowed kinds (``waste``, ``income``,
+  ``move``, ``change``, ``object``, ``currency``, ``tag``, ``accum``). Returns `True` on
+  success, raises `DrebedengiAPIError` on the "other object connected" failure mode so the
+  caller can clean dependants up.
+* `DeletableObjectType` — exported `Literal` alias for the eight valid `object_type` values.
+
 ## [0.2.0] - 2022-11-12
 
 ### Added

--- a/src/drebedengi/api.py
+++ b/src/drebedengi/api.py
@@ -22,7 +22,11 @@ from .model import (
 )
 from .utils import generate_xml_array, xmlmap_to_model
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
+
+DeletableObjectType = Literal[
+    "waste", "income", "move", "change", "object", "currency", "tag", "accum"
+]
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +206,48 @@ class DrebedengiAPI:
         items: List[etree.Element] = root.findall(".//getRecordListReturn/item/value")
 
         return [xmlmap_to_model(item, Transaction, strict=self.strict) for item in items]
+
+    def delete_object(self, *, object_id: int, object_type: DeletableObjectType) -> bool:
+        """
+        Implements deleteObject API — delete a single object on the server.
+
+        Args:
+            object_id: ID of the object to delete.
+            object_type: one of ``"waste"``, ``"income"``, ``"move"``, ``"change"``,
+                ``"object"``, ``"currency"``, ``"tag"``, ``"accum"``.
+                ``"object"`` covers waste categories, income sources and accounts (places).
+                For ``"move"`` and ``"change"`` records, the second part of the pair is
+                deleted automatically by the server.
+
+        Returns:
+            ``True`` on success.
+
+        Raises:
+            DrebedengiAPIError: on any server-side error, including the "other object connected
+                to this ID — delete them first" case (you'll need to delete dependants in the
+                right order).
+
+        Original WSDL description:
+            Delete any object; [id] => ID of the object to delete; [type] => The type of the
+            object, must be one of: 'waste' 'income' 'move' 'change' 'object' 'currency' 'tag'
+            'accum'; 'object' is waste category, income source or place; If 'id' identifies
+            'move' or 'change', both records will be deleted on the server; Returns 1 on
+            success; if an error accures - generates SoapFault message; if there is other
+            object connected to this ID - delete them first;
+        """
+        with self.client.settings(raw_response=True, strict=False):
+            result = self.client.service.deleteObject(
+                self.api_key,
+                self.login,
+                self.password,
+                id=object_id,
+                type=object_type,
+            )
+            DrebedengiAPIError.check_and_raise(result)
+
+        root = etree.fromstring(result.content)
+        ret = root.findtext(".//deleteObjectReturn")
+        return ret == "1"
 
     def get_changes(self, *, revision: int) -> List[ChangeRecord]:
         """

--- a/tests/test_delete_object.py
+++ b/tests/test_delete_object.py
@@ -1,0 +1,51 @@
+"""Unit tests for api.delete_object (mocked HTTP)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from drebedengi import DrebedengiAPI
+
+
+SUCCESS_RESPONSE = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"'
+    b' xmlns:ns1="urn:ddengi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+    b' xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
+    b"<SOAP-ENV:Body><ns1:deleteObjectResponse>"
+    b'<deleteObjectReturn xsi:type="xsd:int">1</deleteObjectReturn>'
+    b"</ns1:deleteObjectResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>"
+)
+
+
+def _mk_api(content: bytes = SUCCESS_RESPONSE) -> DrebedengiAPI:
+    a = DrebedengiAPI.__new__(DrebedengiAPI)
+    a.api_key, a.login, a.password = "k", "l", "p"
+    a.soap_url, a.strict = "fake", True
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.ok = True
+    fake_response.status_code = 200
+    fake_response.content = content
+    fake_client.service.deleteObject.return_value = fake_response
+    fake_client.settings.return_value.__enter__ = lambda self: None
+    fake_client.settings.return_value.__exit__ = lambda *args: None
+    a.client = fake_client
+    return a
+
+
+def test_delete_object_returns_true_on_success() -> None:
+    api = _mk_api()
+    assert api.delete_object(object_id=12345, object_type="waste") is True
+    call_kwargs = api.client.service.deleteObject.call_args.kwargs
+    assert call_kwargs["id"] == 12345
+    assert call_kwargs["type"] == "waste"
+
+
+def test_delete_object_passes_credentials_positionally() -> None:
+    api = _mk_api()
+    api.delete_object(object_id=1, object_type="tag")
+    args = api.client.service.deleteObject.call_args.args
+    assert args == ("k", "l", "p")


### PR DESCRIPTION
Second write method. Independent from #16 — needed for use cases that want to drop a transaction outright (e.g. an interactive categorize-and-write bot offering a 🗑 action). Refs #12.

### What

* `api.delete_object(object_id=..., object_type=...)` — thin wrapper around `deleteObject`.
* `object_type` is constrained via `Literal["waste", "income", "move", "change", "object", "currency", "tag", "accum"]` (exported as `DeletableObjectType`), matching the eight kinds WSDL spells out.
* Returns `True` when the server replies `<deleteObjectReturn>1</deleteObjectReturn>`.
* On the "other object connected to this ID — delete them first" failure mode, the SOAP fault propagates as `DrebedengiAPIError`, so the caller can clean dependants in the right order.

### Tests

* Two unit tests with mocked transport (return value + that credentials are passed positionally).
* Verified live on a real account: created a 0.01 ₽ test record, called `api.delete_object(object_id=..., object_type="waste")`, confirmed the record is gone from `get_transactions`. Server returns `1`.

### Independence from #14 / #15 / #16

This branch is based on `upstream/main` and touches neither the Python version constraint nor `Currency` / `xmlmap_to_model` / `set_record_list`. Merge order doesn't matter.